### PR TITLE
Bugfix/arw ema 143563 type mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 Carthage
 Pods/
 Podfile.lock
+.DS_Store

--- a/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel.m
@@ -406,9 +406,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
                     }
 
                     //set the property value
-                    if (![jsonValue isEqual:[self valueForKey:property.name]]) {
-                        [self setValue:jsonValue forKey: property.name];
-                    }
+                    [self setValue:jsonValue forKey: property.name];
                     continue;
                 }
 
@@ -454,8 +452,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
                         id (*func)(id, SEL, id) = (void *)imp;
                         jsonValue = func(valueTransformer, selector, jsonValue);
 
-                        if (![jsonValue isEqual:[self valueForKey:property.name]])
-                            [self setValue:jsonValue forKey:property.name];
+                        [self setValue:jsonValue forKey:property.name];
                     } else {
                         if (err) {
                             NSString* msg = [NSString stringWithFormat:@"%@ type not supported for %@.%@", property.type, [self class], property.name];

--- a/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel.m
@@ -466,8 +466,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
                     }
                 } else {
                     // 3.4) handle "all other" cases (if any)
-                    if (![jsonValue isEqual:[self valueForKey:property.name]])
-                        [self setValue:jsonValue forKey:property.name];
+                    [self setValue:jsonValue forKey:property.name];
                 }
             }
         }


### PR DESCRIPTION
Removing checks for equality.

Basically, in our Swagger generated files, we set default values like this:

```
    self.sendCcdasToHieEnabled = @0;
    self.showSendCcdasToHieCheckbox = @0;
```

And if the value from the JSON is, say, `false`, then that won't be set on the property. This messes up the conversion to MMD based models, however, as a boxed integer NSNumber doesn't pass its type check, whereas a boxed boolean does.

So… rather than regenerating all of our Swagger projects, just don't perform the equality check before setting property values from the JSON. This might have a minor performance impact, but is unlikely, as I expect the equality check is more expensive than the property assignment.